### PR TITLE
fix: path preload scene 'attack_prota' in gd 'body_prota'

### DIFF
--- a/scripts/body_prota.gd
+++ b/scripts/body_prota.gd
@@ -1,6 +1,6 @@
 extends CharacterBody2D
 
-const BALA = preload("res://Scenes/attack_prota.tscn")
+const BALA = preload("res://scenes/attack_prota.tscn")
 
 const SPEED = 190.0
 #const JUMP_VELOCITY = -400.0


### PR DESCRIPTION
- Error de sintaxis, al escribir el path de la escena 'attack_prota' en el gd del prota, se cambia la S mayuscula que estaba antes por minúscula, para que el archivo gd reconozca la ruta a esa escena